### PR TITLE
Support for Multiple Accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,6 +782,7 @@ dependencies = [
 name = "helium-ledger-app"
 version = "1.1.3-alpha"
 dependencies = [
+ "anyhow",
  "base64",
  "bs58",
  "byteorder",
@@ -796,6 +797,7 @@ dependencies = [
  "qr2term",
  "rust_decimal",
  "structopt",
+ "thiserror",
  "tokio",
 ]
 
@@ -1024,12 +1026,12 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 [[package]]
 name = "ledger-apdu"
 version = "0.7.0"
-source = "git+https://github.com/helium/ledger-rs#66fbede26d8d6281f5070d94f1a224071a53b09a"
+source = "git+https://github.com/helium/ledger-rs#89ed845309e84c6c723de60976fff83c1a868c8c"
 
 [[package]]
 name = "ledger-transport-hid"
 version = "0.7.0"
-source = "git+https://github.com/helium/ledger-rs#66fbede26d8d6281f5070d94f1a224071a53b09a"
+source = "git+https://github.com/helium/ledger-rs#89ed845309e84c6c723de60976fff83c1a868c8c"
 dependencies = [
  "byteorder",
  "cfg-if 0.1.10",

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ else
 	ICONNAME   = nanos_app_helium.gif
 endif
 
-APPVERSION = 1.0.1
+APPVERSION = 2.0.0
 
 # The --path argument here restricts which BIP32 paths the app is allowed to derive.
 ifeq ($(TESTNET),true)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ Please [follow instructions here](https://docs.helium.com/wallets/ledger) to lea
 
 # Development
 
+You can follows the instructions [here](https://ledger.readthedocs.io/en/0/nanos/setup.html#first-app-hello-world
+) from Ledger docs
+
+Another way is to download the BOLOS_SDK for which you are compiling. For example, for Nano X, 
+clone the repo into your home directory
+
+```
+git clone git@github.com:LedgerHQ/nanos-secure-sdk.git
+```
+
+From this helium-ledger repo, you can now build and load the app for the testnet in the following
+way:
+
 ```
 BOLOS_SDK=~/nanos-secure-sdk make TESTNET=true load
 ```
+
+The load will fail unless you are on the app selection screen.

--- a/companion-app/Cargo.toml
+++ b/companion-app/Cargo.toml
@@ -7,6 +7,8 @@ publish = false
 
 
 [dependencies]
+anyhow = "1.0"
+thiserror = "1"
 byteorder = "1"
 structopt = "0"
 helium-api = "2"
@@ -22,4 +24,3 @@ rust_decimal = "1"
 prost = "0"
 qr2term = "0"
 tokio = {version = "1.2", features = ["full"]}
-

--- a/companion-app/src/error.rs
+++ b/companion-app/src/error.rs
@@ -1,0 +1,33 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Could not find ledger. Is it disconnected or locked?")]
+    CouldNotFindLedger,
+    #[error("Ledger is connected but Helium application does not appear to be running")]
+    AppNotRunning,
+    #[error("Error getting version. App must be waiting for a command.")]
+    VersionError,
+    #[error("Error generating QR")]
+    Qr(#[from] qr2term::QrError),
+    #[error("Error accessing Ledger HID Device")]
+    Hid(#[from] ledger::LedgerHIDError),
+    #[error("Helium API Error")]
+    HeliumApi(#[from] helium_api::Error),
+    #[error("Helium Crypto Error")]
+    HeliumCrypto(#[from] helium_crypto::Error),
+    #[error("Getting Fees")]
+    GettingFees,
+    #[error("Io Error")]
+    Io(#[from] std::io::Error),
+    #[error("Decoding Error")]
+    Decode(#[from] prost::DecodeError),
+    #[error("Encoding Error")]
+    Encode(#[from] prost::EncodeError),
+}
+
+impl Error {
+    pub fn getting_fees() -> Error {
+        Error::GettingFees
+    }
+}

--- a/companion-app/src/main.rs
+++ b/companion-app/src/main.rs
@@ -6,12 +6,14 @@ use helium_crypto::{public_key::PublicKey, Network};
 use helium_proto::{BlockchainTxn, BlockchainTxnPaymentV1};
 use ledger_api::*;
 use qr2term::print_qr;
-use std::{env, process};
+use std::{env, fmt, process};
 use structopt::StructOpt;
 
 mod ledger_api;
 
-pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+mod error;
+pub use error::Error;
+pub type Result<T = ()> = std::result::Result<T, Error>;
 
 const DEFAULT_TESTNET_BASE_URL: &str = "https://testnet-api.helium.wtf/v1";
 
@@ -32,11 +34,22 @@ enum Cli {
         /// Display QR code for a given single wallet.
         #[structopt(long = "qr")]
         qr_code: bool,
+        /// Select account index to check balance for
+        /// With scan option, you can display many balances
+        #[structopt(long = "account", default_value = "0")]
+        account: u8,
+        /// Scans all accounts up until selected account index
+        /// This is useful for displaying all balances
+        #[structopt(long = "scan")]
+        scan: bool,
     },
     /// Pay a given address.
-    /// Use subcommand hnt or bones.
-    /// Note that 1 HNT = 100,000,000 Bones = 100M Bones.
-    Pay { payee: Payee },
+    Pay {
+        payee: Payee,
+        /// Select account index to check balance
+        #[structopt(long = "account", default_value = "0")]
+        account: u8,
+    },
 }
 
 #[derive(Debug)]
@@ -72,19 +85,67 @@ async fn main() {
     }
 }
 
-async fn run(cli: Cli) -> Result {
-    match cli {
-        Cli::Balance { qr_code } => {
-            // get pubkey and display it on Ledger Screen
-            let pubkey = ledger_api::get_pubkey(PubkeyDisplay::On)?;
+pub(crate) struct Version {
+    major: u8,
+    minor: u8,
+    revision: u8,
+}
 
-            print_balance(&pubkey).await?;
-            if qr_code {
-                print_qr(&pubkey.to_string())?;
+impl Version {
+    pub(crate) fn from_bytes(bytes: [u8; 3]) -> Version {
+        Version {
+            major: bytes[0],
+            minor: bytes[1],
+            revision: bytes[2],
+        }
+    }
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "v{}.{}.{}", self.major, self.minor, self.revision)
+    }
+}
+
+async fn run(cli: Cli) -> Result {
+    let version = ledger_api::get_version()?;
+    println!("Ledger running Helium {}", version);
+
+    match cli {
+        Cli::Balance {
+            qr_code,
+            account,
+            scan,
+        } => {
+            if version.major < 2 && account != 0 {
+                panic!("Upgrade your the Helium App to use additional wallet accounts");
+            };
+
+            if scan {
+                if qr_code {
+                    println!("WARNING: to output a QR Code, do not use scan")
+                }
+                let mut pubkeys = Vec::new();
+                for i in 0..account {
+                    pubkeys.push(ledger_api::get_pubkey(i, PubkeyDisplay::Off)?);
+                }
+                print_balance(&pubkeys).await?;
+            } else {
+                // get pubkey and display it on Ledger Screen
+                let pubkey = ledger_api::get_pubkey(account, PubkeyDisplay::On)?;
+                let output = pubkey.to_string();
+                print_balance(&vec![pubkey]).await?;
+                if qr_code {
+                    print_qr(&output)?;
+                }
             }
+
             Ok(())
         }
-        Cli::Pay { payee } => {
+        Cli::Pay { payee, account } => {
+            if version.major < 2 && account != 0 {
+                panic!("Upgrade your the Helium App to use additional wallet accounts");
+            };
             let address = payee.address;
             let amount = payee.amount;
             println!("Creating transaction for:");
@@ -97,7 +158,7 @@ async fn run(cli: Cli) -> Result {
             println!("        =");
             println!("      {:} Bones", u64::from(amount));
 
-            match ledger_api::pay(address, amount).await? {
+            match ledger_api::pay(account, address, amount).await? {
                 PayResponse::Txn(txn, hash) => print_txn(&txn, &hash).unwrap(),
                 PayResponse::InsufficientBalance(balance, send_request) => {
                     println!(
@@ -118,29 +179,55 @@ async fn run(cli: Cli) -> Result {
 use helium_api::{accounts, Client};
 use prettytable::{format, Table};
 
-async fn print_balance(pubkey: &PublicKey) -> Result {
-    let client = Client::new_with_base_url(api_url(pubkey.network));
-    let address = pubkey.to_string();
-    let result = accounts::get(&client, &address).await;
+async fn print_balance(pubkeys: &[PublicKey]) -> Result {
+    // sample the first pubkey to determine network
+    let network = pubkeys[0].network;
+
+    let client = Client::new_with_base_url(api_url(network));
     let mut table = Table::new();
     table.set_format(*format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
-
-    let balance = match pubkey.network {
+    let balance = match network {
         Network::TestNet => "Balance TNT",
         Network::MainNet => "Balance HNT",
     };
 
-    table.set_titles(row!["Address", balance, "Data Credits", "Security Tokens"]);
-
-    match result {
-        Ok(account) => table.add_row(row![
-            address,
-            account.balance,
-            account.dc_balance,
-            account.sec_balance
-        ]),
-        Err(err) => table.add_row(row![address, H3 -> err.to_string()]),
-    };
+    if pubkeys.len() > 1 {
+        table.set_titles(row![
+            "Index",
+            "Address",
+            balance,
+            "Data Credits",
+            "Security Tokens"
+        ]);
+    } else {
+        table.set_titles(row!["Address", balance, "Data Credits", "Security Tokens"]);
+    }
+    for (account_index, pubkey) in pubkeys.iter().enumerate() {
+        let address = pubkey.to_string();
+        let result = accounts::get(&client, &address).await;
+        if pubkeys.len() > 1 {
+            match result {
+                Ok(account) => table.add_row(row![
+                    account_index,
+                    address,
+                    account.balance,
+                    account.dc_balance,
+                    account.sec_balance
+                ]),
+                Err(err) => table.add_row(row![account_index, address, H3 -> err.to_string()]),
+            };
+        } else {
+            match result {
+                Ok(account) => table.add_row(row![
+                    address,
+                    account.balance,
+                    account.dc_balance,
+                    account.sec_balance
+                ]),
+                Err(err) => table.add_row(row![address, H3 -> err.to_string()]),
+            };
+        }
+    }
 
     table.printstd();
     Ok(())

--- a/src/get_public_key.c
+++ b/src/get_public_key.c
@@ -90,7 +90,7 @@ void handle_get_public_key(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16_t
 #else
 	G_io_apdu_buffer[1] = NETTYPE_MAIN | KEYTYPE_ED25519;
 #endif
-	get_pubkey_bytes(&G_io_apdu_buffer[adpu_tx]);
+	get_pubkey_bytes(p2, &G_io_apdu_buffer[adpu_tx]);
 	adpu_tx += SIZE_OF_PUB_KEY_BIN;
 
 	cx_sha256_t hash;

--- a/src/helium.h
+++ b/src/helium.h
@@ -32,7 +32,7 @@ typedef struct transaction_arg_t {
 extern bool sign_transaction;
 extern uint16_t txn_length;
 
-uint32_t create_helium_transaction();
+uint32_t create_helium_pay_txn(uint8_t account_index);
 
 #define SIZE_OF_PUB_KEY_BIN 	32
 #define SIZE_OF_SHA_CHECKSUM 	4
@@ -46,8 +46,7 @@ uint32_t create_helium_transaction();
 #define P1_PUBKEY_DISPLAY_ON	0x01
 #define P1_PUBKEY_DISPLAY_OFF 	0x00
 
-void get_pubkey_bytes(uint8_t * out);
-
+void get_pubkey_bytes(uint8_t account_index, uint8_t * out);
 #define MAX_ENC_INPUT_SIZE 120
 
 int btchip_encode_base58(const unsigned char *in, size_t length,

--- a/src/helium_ux.h
+++ b/src/helium_ux.h
@@ -22,6 +22,7 @@ typedef struct {
 	// to be scrolled.
 	uint8_t partialStr[13];
 	uint8_t fullStr_len;
+	uint8_t account_index;
 	uint64_t amount;
 	uint64_t nonce;
 	uint64_t fee;

--- a/src/sign_payment_txn.c
+++ b/src/sign_payment_txn.c
@@ -43,7 +43,7 @@ static unsigned int ui_signTxn_approve_button(unsigned int button_mask, unsigned
 
 	case BUTTON_RIGHT:
 	case BUTTON_EVT_FAST | BUTTON_RIGHT: // SEEK RIGHT
-		adpu_tx = create_helium_transaction();
+		adpu_tx = create_helium_pay_txn(ctx->account_index);
 		io_exchange_with_code(SW_OK, adpu_tx);
 		ui_idle();
 		break;
@@ -242,6 +242,7 @@ void handle_sign_payment_txn(uint8_t p1, uint8_t p2, uint8_t *dataBuffer, uint16
 	ctx->amount = U8LE(dataBuffer, 0);
 	ctx->fee  = U8LE(dataBuffer, 8);
 	ctx->nonce = U8LE(dataBuffer, 16);
+	ctx->account_index = p1;
 	os_memmove(ctx->payee, &dataBuffer[24], sizeof(ctx->payee));
 
 	// display amount on screen


### PR DESCRIPTION
Adds support so that a single Ledger can manage up to 255 wallets.

The companion client demands major version greather than 2 when a account other than 0 is used. Since the p1/p2 fields of the APDU are used and these are default to 0 in previous companion app versions, there are otherwise no compatibility concerns. That is to say, new Ledger firmware will work well with old versions of companion app.

Error handling is updated to use thiserror and anyhow.